### PR TITLE
Update prebuilt to gcc 5.3, other changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,9 @@
 #
 
 STANDALONE = y
-PREBUILT_TOOLCHAIN = n
+PREBUILT_TOOLCHAIN = y
 DEBUG = n
-UTILS = n
+UTILS = y
 CROSS_TARGET = n
 TOOLCHAIN_ONLY = n
 
@@ -55,9 +55,9 @@ BINUTILS_DIR = binutils-$(BINUTILS_VERSION)
 
 GCC_DIR = gcc-$(GCC_VERSION)
 
-XTENSA_TOOLCHAIN_WINDOWS_TAR := xtensa-lx106-elf-v5.1.0.64-windows-x86.zip
-XTENSA_TOOLCHAIN_MAC_TAR := xtensa-lx106-elf-v5.1.0.64-macos-x86_64.zip
-XTENSA_TOOLCHAIN_LINUX_TAR := xtensa-lx106-elf-v5.1.0.64-linux-x86_64.tar.gz
+XTENSA_TOOLCHAIN_WINDOWS_TAR := xtensa-lx106-elf-v5.3.0.83-windows-x86.zip
+XTENSA_TOOLCHAIN_MAC_TAR := xtensa-lx106-elf-v5.3.0.83-macos-x86_64.zip
+XTENSA_TOOLCHAIN_LINUX_TAR := xtensa-lx106-elf-v5.3.0.83-linux-x86_64.tar.gz
 
 #NEWLIB_DIR = newlib-$(NEWLIB_VERSION)
 NEWLIB_DIR = newlib-xtensa
@@ -85,7 +85,7 @@ endif
 PLATFORM := $(shell uname -s)
 
 
-SAFEPATH := $(TOOLCHAIN)/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin::/mingw/bin/:/c/tools/mingw32/bin:/c/tools/mingw64/bin:/mingw32:/mingw32/bin:/c/windows/system32
+SAFEPATH := $(TOOLCHAIN)/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin::/mingw/bin/:/c/tools/mingw32/bin:/c/tools/mingw64/bin:/mingw32:/mingw32/bin:/c/windows/system32:/c/tools/python2-x86_32/Scripts:/c/Program\ Files\ \(x86\)/Mono-3.2.3/bin
 PATH := $(SAFEPATH)
 #PATH := $(TOOLCHAIN)/bin:$(PATH)
 
@@ -186,7 +186,7 @@ $(UTILS_DIR)/esptool: $(XTDLP)/$(ESPTOOL_DIR)/esptool.py
 $(UTILS_DIR)/memanalyzer: $(XTDLP)/$(MEMANALYZER_DIR)/MemAnalyzer.sln
 	mkdir -p $(UTILS_DIR)/
 
-	cd $(XTDLP)/$(MEMANALYZER_DIR)/MemAnalyzer/; mcs Program.cs
+	cd $(XTDLP)/$(MEMANALYZER_DIR)/MemAnalyzer/; PATH=$(SAFEPATH) mcs Program.cs
 
   ifeq ($(OS),Windows_NT)
 		cd $(XTDLP)/$(MEMANALYZER_DIR)/MemAnalyzer/; cp Program.exe $(UTILS_DIR)/memanalyzer.exe
@@ -628,15 +628,20 @@ platform-specific:
       endif
     else
       ifneq (,$(findstring MSYS,$(PLATFORM)))
-				@echo "Detected: MSYS."
+			@echo "Detected: MSYS."
+            ifeq ($(PREBUILT_TOOLCHAIN),y)
+				$(MAKE) prebuilt-toolchain-windows
+				$(MAKE) build-prebuilt-toolchain
+            else				
 				$(MAKE) build PATH="/c/msys32/bin:/c/tools/msys32/mingw32/bin:$(PATH)" BUILD_TARGET=i686-w64-mingw32 HOST_TARGET=i686-w64-mingw32
+            endif
       endif
     endif
   endif
 
   ifneq (,$(findstring CYGWIN,$(PLATFORM)))
 		@echo "Detected: CYGWIN"
-   ifeq ($(PREBUILT_TOOLCHAIN),y)
+    ifeq ($(PREBUILT_TOOLCHAIN),y)
 			$(MAKE) prebuilt-toolchain-windows
 			$(MAKE) build-prebuilt-toolchain
     else

--- a/env/msys2_10.cmd
+++ b/env/msys2_10.cmd
@@ -1,15 +1,41 @@
-echo Upgrading Chocolatey
-choco update chocolatey
+@echo off
+echo ###############################################
+echo ###### Configuring environment for msys2 ######
+echo ###############################################
+echo ***** Upgrading Chocolatey *****
+choco update chocolatey -y
 
-echo Add repository
+echo ***** Add Chocolatey repository *****
 choco sources add -name kireevco -source 'https://www.myget.org/F/kireevco-chocolatey/'
 
-echo Install msys2
+echo ***** Installing msys2 *****
 choco install msys2 -y
 
+echo ***** Installing msys2 Packages *****
 set PATH=c:\tools\msys64\usr\bin\;%PATH%
 bash update-core
 pacman -sU
 
-echo Install Packages
 pacman -S git autoconf automake wget bsdtar zip mingw-w64-i686-toolchain mingw-w64-i686-isl make gettext texinfo bison flex patch upx --noconfirm
+
+echo ***** Installing Extra Packages for building exe from python ***** 
+::pacman -S python2 mingw-w64-i686-python2-pip
+choco install python2-x86_32 -y
+easy_install --always-unzip pyserial
+
+echo Install pyinstaller
+pip install pyinstaller
+
+
+echo [build] > c:\tools\python2-x86_32\Lib\distutils\distutils.cfg
+echo compiler = mingw32 >> c:\tools\python2-x86_32\Lib\distutils\distutils.cfg
+
+echo ***** Installing Mono ***** 
+choco install mono -version 3.2.3 -y
+
+echo ***** Adding ENV variables *****
+setx /M PATH "C:\Program Files (x86)\Mono-3.2.3\bin;%PATH%" && set PATH=C:\Program Files(x86)\Mono-3.2.3\bin;%PATH%
+
+echo ###############################################
+echo ############ Done. Now run `make` #############
+echo ###############################################


### PR DESCRIPTION
Update prebuilt to gcc 5.3, Utils are default now, Prebuilt toolchan is default, Safepath inculdes mono, add msys platform prebuilt, add required pyinstaller, mono packages to env/msys
